### PR TITLE
updating the react-native-modal in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/srk-sharingan/sharingan-rn-modal-dropdown#readme",
   "dependencies": {
     "lodash": "^4.17.20",
-    "react-native-modal": "^11.5.6"
+    "react-native-modal": "^13.0.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^8.3.4",


### PR DESCRIPTION
I'm facing this issue while using dropdown in Stack navigation modal screen while close it throw below error .

TypeError: undefined is not a function
This error is located at:
in ReactNativeModal (created by Dropdown)
in RCTView (created by View)

so i updating the react-native-modal version to latest